### PR TITLE
Ignore CLion project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Cargo.lock
 
 # Repo assets and temporary files
 /assets/
+
+# CLion project files
+/.idea/


### PR DESCRIPTION
CLion creates `.idea` directory which can be ignored.