### PR TITLE
remove: Path field from lev and rec

### DIFF
--- a/src/lev.rs
+++ b/src/lev.rs
@@ -232,8 +232,6 @@ pub struct Level {
     pub pictures: Vec<Picture>,
     /// Best times lists.
     pub best_times: BestTimes,
-    /// Level path, if loaded/saved.
-    pub path: Option<PathBuf>,
 }
 
 impl Default for Level {
@@ -287,7 +285,6 @@ impl Level {
     /// ```
     pub fn new() -> Self {
         Level {
-            path: None,
             version: Version::Elma,
             link: random::<u32>(),
             integrity: [0f64; 4],
@@ -330,8 +327,7 @@ impl Level {
     pub fn load<P: Into<PathBuf>>(path: P) -> Result<Self, ElmaError> {
         let path = path.into();
         let buffer = fs::read(path.as_path())?;
-        let mut lev = Level::parse_level(&buffer)?;
-        lev.path = Some(path);
+        let lev = Level::parse_level(&buffer)?;
         Ok(lev)
     }
 
@@ -820,7 +816,6 @@ impl Level {
         let bytes = self.to_bytes(top10)?;
         let path = path.into();
         fs::write(&path.as_path(), &bytes)?;
-        self.path = Some(path);
         Ok(())
     }
 }

--- a/src/rec.rs
+++ b/src/rec.rs
@@ -198,8 +198,6 @@ pub struct Replay {
     pub link: u32,
     /// Full level filename.
     pub level: String,
-    /// Path to file.
-    pub path: Option<PathBuf>,
     /// Rides of players.
     pub rides: Vec<Ride>,
 }
@@ -315,7 +313,6 @@ fn parse_replay(input: &[u8]) -> IResult<&[u8], Replay> {
         flag_tag: players[0].0.flag_tag,
         link: players[0].0.link,
         level: players[0].0.level.clone(),
-        path: None,
         rides: players.into_iter().map(|(_, ride)| ride).collect(),
     };
 
@@ -335,7 +332,6 @@ impl Replay {
             flag_tag: false,
             link: 0,
             level: String::new(),
-            path: None,
             rides: vec![],
         }
     }
@@ -351,8 +347,7 @@ impl Replay {
     pub fn load<P: Into<PathBuf>>(path: P) -> Result<Self, ElmaError> {
         let path = path.into();
         let buffer = fs::read(path.as_path())?;
-        let mut rec = Replay::parse_replay(&buffer)?;
-        rec.path = Some(path);
+        let rec = Replay::parse_replay(&buffer)?;
         Ok(rec)
     }
 
@@ -409,7 +404,6 @@ impl Replay {
     pub fn save<P: Into<PathBuf>>(&mut self, path: P) -> Result<(), ElmaError> {
         let path = path.into();
         fs::write(path.as_path(), &self.to_bytes()?)?;
-        self.path = Some(path);
         Ok(())
     }
 

--- a/tests/lev.rs
+++ b/tests/lev.rs
@@ -25,7 +25,6 @@ fn decrypt_encrypt_top10() {
 /// Generate a level with some arbitrary values and see if it saves.
 fn construct_level_and_save() {
     let mut level = Level {
-        path: None,
         version: Version::default(),
         link: random::<u32>(),
         integrity: [0f64; 4],
@@ -322,8 +321,7 @@ fn load_valid_level_2() {
 fn load_valid_level_2_from_bytes() {
     let level = Level::load("tests/assets/levels/test_2.lev").unwrap();
     let buffer = fs::read("tests/assets/levels/test_2.lev").unwrap();
-    let mut buf_lev = Level::from_bytes(&buffer).unwrap();
-    buf_lev.path = Some("tests/assets/levels/test_2.lev".into());
+    let buf_lev = Level::from_bytes(&buffer).unwrap();
     assert_eq!(level, buf_lev);
 }
 

--- a/tests/rec.rs
+++ b/tests/rec.rs
@@ -51,7 +51,6 @@ fn rec_default_values() {
             flag_tag: false,
             link: 0,
             level: String::new(),
-            path: None,
             rides: vec![],
         }
     );
@@ -226,8 +225,7 @@ fn load_valid_replay_1_and_save() {
 
 #[test]
 fn load_valid_replay_1_from_buffer() {
-    let mut replay = Replay::load(PATH_TEST_1).unwrap();
-    replay.path = None; // remove path for easier equality check
+    let replay = Replay::load(PATH_TEST_1).unwrap();
     let buffer = fs::read(PATH_TEST_1).unwrap();
     assert_eq!(replay, Replay::from_bytes(&buffer).unwrap());
 }


### PR DESCRIPTION
This removes path field from Level and Replay.

My thinking is something like:

* Path is not really a property of levs or recs (or any other elma object). It just talks about "where" it came from, which really could be anywhere (internet, etc...)
* It's better to define (in application code, not in this crate) something like FilesystemLevel(Level, PathBuf) which is more precise (as a type) than just a Level with an optional path. Similarly for internal levs, e.g. InternalLevel(Level, usize) so they never have a path.
* Also gets rid of a workaround in a test :P